### PR TITLE
Allow you to hide resource

### DIFF
--- a/src/Http/Controllers/ImportController.php
+++ b/src/Http/Controllers/ImportController.php
@@ -36,6 +36,10 @@ class ImportController
         $sample = $import->take(10)->all();
 
         $resources = collect(Nova::$resources);
+        
+        $resources = $resources->filter(function ($resource) {
+            return isset($resource::$canImportResource) && $resource::$canImportResource;
+        });
 
         $fields = $resources->map(function ($resource) {
             $model = $resource::$model;

--- a/src/Http/Controllers/ImportController.php
+++ b/src/Http/Controllers/ImportController.php
@@ -38,7 +38,7 @@ class ImportController
         $resources = collect(Nova::$resources);
         
         $resources = $resources->filter(function ($resource) {
-            return isset($resource::$canImportResource) && $resource::$canImportResource;
+            return property_exists((string) $resource, 'canImportResource') && $resource::$canImportResource;
         });
 
         $fields = $resources->map(function ($resource) {

--- a/src/Http/Controllers/ImportController.php
+++ b/src/Http/Controllers/ImportController.php
@@ -38,7 +38,13 @@ class ImportController
         $resources = collect(Nova::$resources);
         
         $resources = $resources->filter(function ($resource) {
-            return property_exists((string) $resource, 'canImportResource') && $resource::$canImportResource;
+            $static_vars = (new \ReflectionClass((string) $resource))->getStaticProperties();
+            
+            if(!isset($static_vars['canImportResource'])) {
+                return true;
+            }
+
+            return isset($static_vars['canImportResource']) && $static_vars['canImportResource'];
         });
 
         $fields = $resources->map(function ($resource) {


### PR DESCRIPTION
This PR allows you to exclude a resource.

Uses:
- Resource doesn't need to be imported
- Resource has a field that causes this package to break