### PR TITLE
Fixed preview 404ing if a resource has a BelongsTo field

### DIFF
--- a/src/Http/Controllers/ImportController.php
+++ b/src/Http/Controllers/ImportController.php
@@ -8,6 +8,7 @@ use Laravel\Nova\Rules\Relatable;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use SimonHamp\LaravelNovaCsvImport\Importer;
 use Illuminate\Validation\ValidationException;
+use Laravel\Nova\Fields\Field;
 
 class ImportController
 {
@@ -42,7 +43,14 @@ class ImportController
 
             return new $resource(new $model);
         })->mapWithKeys(function (Resource $resource) use ($request) {
-            return [$resource->uriKey() => $resource->creationFields($request)];
+            $fields = collect($resource->creationFields($request))
+                ->map(function (Field $field) {
+                    return [
+                        'name' => $field->name,
+                        'attribute' => $field->attribute
+                    ];
+                });
+            return [$resource->uriKey() => $fields];
         });
 
         $resources = $resources->mapWithKeys(function ($resource) {


### PR DESCRIPTION
Fixed #16 and #17

This issue stems from how Nova serialises `BelongsTo` fields to JSON. Take a look at `Laravel\Nova\Fields\Field::sortableUriKey()`. This gets called when a field is serialised to JSON (see `jsonSerialize()` in the same file). The problem is that it tries to create a new resource based on the request, but there is no resource related to this request hence the 404.

Since the only field data that's actually used is `name` and `attribute`, I just made it grab those directly and avoid getting all the other serialised stuff that isn't being used.