### PR TITLE
Minor Fixes 

### DIFF
--- a/resources/js/pages/Configure.vue
+++ b/resources/js/pages/Configure.vue
@@ -225,7 +225,7 @@ export default {
                 // Reset all of the mappings and any custom values
                 for (let {name, attribute} of fields) {
                     this.mappings[attribute] = "";
-                    this.values = "";
+                    this.values = {};
                 }
 
                 // For each field of the resource, try to find a matching heading and pre-assign

--- a/resources/js/pages/Review.vue
+++ b/resources/js/pages/Review.vue
@@ -56,7 +56,7 @@
                                             </BasicButton>
                                             <div v-show="showFailureData[rowIndex]">
                                                 <div v-for="(value, key) in problem.values">
-                                                    {{ config.map[key] }} &rightarrow; {{ key }} :
+                                                    {{ config.mappings[key] }} &rightarrow; {{ key }} :
                                                     <code>
                                                         {{ value }}
                                                         <i v-if="! value">null</i>
@@ -112,7 +112,7 @@
                                             </BasicButton>
                                             <div v-show="showErrorData[rowIndex]">
                                                 <div v-for="(value, key) in problem.values">
-                                                    {{ config.map[key] }} &rightarrow; {{ key }} :
+                                                    {{ config.mappings[key] }} &rightarrow; {{ key }} :
                                                     <code>
                                                         {{ value }}
                                                         <i v-if="! value">null</i>


### PR DESCRIPTION
Two minor fixes - one for a bug on the Configuration page where a type error is created when saving "custom" Single Value field. 
The solution was to change 
`this.values = ""`  to `this.values = {}` on the reset so the values are not typed to String

The second fix is the reference to `config.map[key]` in the review screen (to see errors/failed updates). This works when set to `config.mappings[key]`