### PR TITLE
Feature: Add modifier for Default Values 

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,0 +1,21 @@
+name: Build Assets
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest 
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: composer update
+
+      - run: ./vendor/bin/pint
+      
+      - run: |
+          git config --global user.name 'Simon Hamp'
+          git config --global user.email 'simon.hamp@me.com'
+          if git add * ; then
+            git commit -m "Code style fixes"
+            git push
+          fi

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,6 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "statement_indentation": true
+    }
+}

--- a/src/Concerns/HasModifiers.php
+++ b/src/Concerns/HasModifiers.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use SimonHamp\LaravelNovaCsvImport\Contracts\Modifier;
 use SimonHamp\LaravelNovaCsvImport\Modifiers\Boolean;
+use SimonHamp\LaravelNovaCsvImport\Modifiers\DefaultValue;
 use SimonHamp\LaravelNovaCsvImport\Modifiers\ExcelDate;
 use SimonHamp\LaravelNovaCsvImport\Modifiers\Hash;
 use SimonHamp\LaravelNovaCsvImport\Modifiers\Prefix;
@@ -23,6 +24,7 @@ trait HasModifiers
         // Register built-in modifiers
         static::registerModifiers(
             new Boolean,
+            new DefaultValue,
             new ExcelDate,
             new StrModifier,
             new Hash,

--- a/src/Modifiers/DefaultValue.php
+++ b/src/Modifiers/DefaultValue.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SimonHamp\LaravelNovaCsvImport\Modifiers;
+
+use SimonHamp\LaravelNovaCsvImport\Contracts\Modifier;
+
+class DefaultValue implements Modifier
+{
+  public function title(): string
+  {
+    return 'Default Value';
+  }
+
+  public function description(): string
+  {
+    return "Set a default value for the field if the CSV column is empty or missing";
+  }
+
+  public function settings(): array
+  {
+    return [
+      'string' => [
+        'type' => 'string',
+        'title' => 'Default Value',
+      ],
+    ];
+  }
+
+  public function handle($value = null, array $settings = []): string
+  {
+    return empty($value) ? $settings['string'] : $value;
+  }
+}

--- a/src/Modifiers/DefaultValue.php
+++ b/src/Modifiers/DefaultValue.php
@@ -6,28 +6,28 @@ use SimonHamp\LaravelNovaCsvImport\Contracts\Modifier;
 
 class DefaultValue implements Modifier
 {
-  public function title(): string
-  {
-    return 'Default Value';
-  }
+    public function title(): string
+    {
+        return 'Default Value';
+    }
 
-  public function description(): string
-  {
-    return "Set a default value for the field if the CSV column is empty or missing";
-  }
+    public function description(): string
+    {
+        return 'Set a default value for the field if the CSV column is empty or missing';
+    }
 
-  public function settings(): array
-  {
-    return [
-      'string' => [
-        'type' => 'string',
-        'title' => 'Default Value',
-      ],
-    ];
-  }
+    public function settings(): array
+    {
+        return [
+            'string' => [
+                'type' => 'string',
+                'title' => 'Default Value',
+            ],
+        ];
+    }
 
-  public function handle($value = null, array $settings = []): string
-  {
-    return empty($value) ? $settings['string'] : $value;
-  }
+    public function handle($value = null, array $settings = []): string
+    {
+        return empty($value) ? $settings['string'] : $value;
+    }
 }

--- a/src/Modifiers/DefaultValue.php
+++ b/src/Modifiers/DefaultValue.php
@@ -28,6 +28,6 @@ class DefaultValue implements Modifier
 
     public function handle($value = null, array $settings = []): string
     {
-        return empty($value) ? $settings['string'] : $value;
+        return $value === null ? $settings['string'] : $value;
     }
 }


### PR DESCRIPTION
This PR introduces the `DefaultValue` modifer. This allows you to set a default value for a column only if the value is empty or null without overwriting the value if it is set.

See screenshots below.

**Configure** 
![Screenshot 2023-04-21 at 14-23-16 Ampersand - Configure Import](https://user-images.githubusercontent.com/11492966/233708648-284cf359-6409-4425-b5bb-c7beba67c78c.png)
**Modifier**
![image](https://user-images.githubusercontent.com/11492966/233708705-19b4c891-9169-4ed1-9a38-9f94a129aea7.png)
**Review**
![Screenshot 2023-04-21 at 14-25-01 Ampersand - Import Preview](https://user-images.githubusercontent.com/11492966/233708962-ad8f651e-7fbc-4c59-98aa-098d67a51197.png)
