### PR TITLE
Feature/combinator plus plus

### DIFF
--- a/resources/js/components/FieldCombinator.vue
+++ b/resources/js/components/FieldCombinator.vue
@@ -3,10 +3,9 @@
         <h4 class="text-base font-bold">Combine multiple columns</h4>
 
         <p>
-            Select any number of fields from your import file to be combined. Fields are
-            simply concatenated. Use the <code>separator</code> field to define how they
-            should be concatenated. If you don't choose a separator, the fields will be
-            imported as an array.
+            Select any number of fields from your import file to be combined. Fields are simply concatenated. Use the
+            <code>separator</code> field to define how they should be concatenated. If you don't choose a separator,
+            the fields will be imported as an array.
         </p>
 
         <SelectControl @change="(value) => rawSeparator = value" :selected="separatorOption">
@@ -28,10 +27,32 @@
             <template #item="{ element, index }">
                 <div class="flex mb-2 space-x-2 items-start border-rounded bg-gray-100 p-2 handle">
                     <div>{{ index + 1 }}</div>
-                    <SelectControl @change="(value) => columns[index] = value" :selected="columns[index]">
+
+                    <SelectControl @change="(value) => columns[index].name = value" :selected="columns[index].name">
                         <option value="">- Select field -</option>
-                        <option v-for="heading in headings" :value="heading">{{ heading }}</option>
+
+                        <optgroup label="Imported column">
+                            <option v-for="heading in headings" :value="heading">{{ heading }}</option>
+                        </optgroup>
+
+
+                        <optgroup label="Custom - same value for each row">
+                            <option value="custom">Custom value</option>
+                        </optgroup>
                     </SelectControl>
+
+                    <label class="flex items-center space-x-2" v-if="columns[index].name === 'custom'">
+                        <span>Value</span>
+                        <input v-model="columns[index].value"
+                            class="form-control form-input form-input-bordered flex-1">
+                    </label>
+
+                    <label v-if="! rawSeparator">
+                        as
+                        <input v-model="columns[index].as"
+                            class="form-control form-input form-input-bordered mx-2">
+                    </label>
+
                     <button @click="remove(index)">&times;</button>
                 </div>
             </template>
@@ -106,11 +127,24 @@ export default {
 
     methods: {
         add() {
-            this.columns.push('');
+            if (Array.isArray(this.columns)) {
+                this.columns.push(this.template());
+                return;
+            }
+
+            this.columns = [this.template()];
         },
 
         remove(index) {
             this.columns.splice(index, 1);
+        },
+
+        template() {
+            return {
+                name: '',
+                as: null,
+                value: null,
+            };
         },
 
         update() {

--- a/resources/js/components/FieldCombinator.vue
+++ b/resources/js/components/FieldCombinator.vue
@@ -35,6 +35,12 @@
                             <option v-for="heading in headings" :value="heading">{{ heading }}</option>
                         </optgroup>
 
+                        <optgroup label="Meta data">
+                            <option value="meta.file">File name (with suffix): {{ meta.file }}</option>
+                            <option value="meta.file_name">File name (without suffix): {{ meta.file_name }}</option>
+                            <option value="meta.original_file">Original file name (with suffix): {{ meta.original_file }}</option>
+                            <option value="meta.original_file_name">Original file name (without suffix): {{ meta.original_file_name }}</option>
+                        </optgroup>
 
                         <optgroup label="Custom - same value for each row">
                             <option value="custom">Custom value</option>
@@ -77,6 +83,7 @@ export default {
         'attribute',
         'config',
         'headings',
+        'meta',
     ],
     
     data() {

--- a/resources/js/components/FieldCombinator.vue
+++ b/resources/js/components/FieldCombinator.vue
@@ -28,7 +28,7 @@
                 <div class="flex mb-2 space-x-2 items-start border-rounded bg-gray-100 p-2 handle">
                     <div>{{ index + 1 }}</div>
 
-                    <SelectControl @change="(value) => columns[index].name = value" :selected="columns[index].name">
+                    <SelectControl @change="(value) => changeField(index, value)" :selected="columns[index].name">
                         <option value="">- Select field -</option>
 
                         <optgroup label="Imported column">
@@ -161,6 +161,15 @@ export default {
                 columns: this.columns,
                 separator: this.rawSeparator,
             });
+        },
+
+        changeField(index, value) {
+            this.columns[index].name = value;
+
+            // Reset 'value' when needed
+            if (value !== 'custom') {
+                this.columns[index].value = '';
+            }
         }
     }
 }

--- a/resources/js/pages/Configure.vue
+++ b/resources/js/pages/Configure.vue
@@ -99,6 +99,12 @@
                 :attribute="field.attribute"
                 :config="combined[field.attribute]"
                 :headings="headings"
+                :meta="{
+                    'file': file,
+                    'file_name': file_name,
+                    'original_file': config.original_filename,
+                    'original_file_name': original_file_name,
+                }"
                 @update="setFieldCombinators">
             </FieldCombinator>
 
@@ -109,6 +115,7 @@
                     class="form-control form-input form-input-bordered flex-1">
             </label>
 
+            <!-- Random string length -->
             <label class="flex items-center space-x-2" v-if="mappings[field.attribute] === 'random'">
                 <span>Length</span>
                 <input v-model="random[field.attribute]"

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -156,7 +156,7 @@ class Importer implements ToModel, WithValidation, WithHeadingRow, WithMapping, 
             $outputs = [];
             $config = $this->combined_values[$key];
 
-            foreach ($config['columns'] as $field) {
+            foreach ($config['columns'] as $index => $field) {
                 $value = $field['value'] ?? false ?: $this->getFieldValue($row, $field['name'], $key);
 
                 // If some part of the value looks like a field name (e.g. `{{ name }}`), then replace that part for
@@ -170,7 +170,7 @@ class Importer implements ToModel, WithValidation, WithHeadingRow, WithMapping, 
                 if ($field['as'] ?? false) {
                     Arr::set($outputs, $field['as'], $value);
                 } else {
-                    $outputs[$field['name']] = $value;
+                    $outputs[$field['name'].'_'.$index] = $value;
                 }
             }
 

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -3,6 +3,7 @@
 namespace SimonHamp\LaravelNovaCsvImport;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Laravel\Nova\Resource;
@@ -156,7 +157,13 @@ class Importer implements ToModel, WithValidation, WithHeadingRow, WithMapping, 
             $config = $this->combined_values[$key];
 
             foreach ($config['columns'] as $field) {
-                $outputs[] = $this->getFieldValue($row, $field, $key);
+                $value = $field['value'] ?? false ?: $this->getFieldValue($row, $field['name'], $key);
+
+                if ($field['as'] ?? false) {
+                    Arr::set($outputs, $field['as'], $value);
+                } else {
+                    $outputs[$field['name']] = $value;
+                }
             }
 
             if ($config['separator']) {

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -159,6 +159,14 @@ class Importer implements ToModel, WithValidation, WithHeadingRow, WithMapping, 
             foreach ($config['columns'] as $field) {
                 $value = $field['value'] ?? false ?: $this->getFieldValue($row, $field['name'], $key);
 
+                // If some part of the value looks like a field name (e.g. `{{ name }}`), then replace that part for
+                // the actual value of that field
+                if (is_string($value) && preg_match_all('/{{\s*([a-z0-9_\.]+)\s*}}/i', $value, $matches)) {
+                    foreach ($matches[1] as $match) {
+                        $value = preg_replace('/{{\s*'.$match.'\s*}}/', $this->getFieldValue($row, $match, $key), $value);
+                    }
+                }
+
                 if ($field['as'] ?? false) {
                     Arr::set($outputs, $field['as'], $value);
                 } else {


### PR DESCRIPTION
- Can now use custom values in combinator
- When importing as an array, values will now have an associated key (defaults to the original field name), but can be overridden using the `as` field
- Can use dot-notation in the `as` field to create well-structured arrays
- Can now use meta fields in the combinator